### PR TITLE
remove sub autostart

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -152,7 +152,7 @@ function handleFileSelect(e) {
 			var totalTime = 0;
 			var time0 = Date.now();
 			var deltaT;
-			var paused = false;
+			var paused = true;
 			
 			setInterval(function() {
 				if (paused == false) {
@@ -165,14 +165,14 @@ function handleFileSelect(e) {
 						var playTime = totalTime + deltaT;
 						if (parseFloat(subtitles[i].start) <= playTime &&
 								playTime <= parseFloat(subtitles[i].end)) {
-							ppp.innerText = /*"[" + playTime + "]" + */subtitles[i].text;
+							ppp.innerText = "[" + playTime + "]" + subtitles[i].text;
 							console.log(deltaT + " #" + i + " "+ subtitles[i].text);
 							//alert(deltaT + " #" + i + " "+ subtitles[i].text);
 							break;
 						} else {
 							//console.log("deleting " + subtitles[i].start + " " + deltaT + " " +
 							//		subtitles[i].end);
-							ppp.innerText = /*"[" + playTime + "]" +*/ "";
+							ppp.innerText = "[" + playTime + "]" + "";
 						}
 					}
 				}

--- a/msg.txt
+++ b/msg.txt
@@ -1,5 +1,5 @@
 1
-00:00:17,385 --> 00:00:21,530
+00:00:01,385 --> 00:00:21,530
 The Simpsons 20x01
 Sex, Pies and Idiot Scrapes
 


### PR DESCRIPTION
Currently the subtitle play start immediately after loading the .srt
file. That behaviour shall be changed so that the first SPACE hit starts
video and subtitle synchronously.

- init pause = true
- modify test .srt to have text after 1 second